### PR TITLE
H-AI bugfixes and improvements

### DIFF
--- a/AAUnlimited/Functions/AAPlay/HAis/ForceAi.h
+++ b/AAUnlimited/Functions/AAPlay/HAis/ForceAi.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <array>
+#include <ctime>
 
 #include "External\ExternalClasses\HClasses\HGUIButton.h"
 #include "External\ExternalClasses\HClasses\HInfo.h"


### PR DESCRIPTION
After noticing some odd behavior in-game, I started tinkering with the H-AI code to make it work more like how it's described in the readme, and I figured it might be worthwhile to share what I did. Notable changes/fixes include:

- Fixed a bug in the pref position selection algorithm where certain positions wouldn't be found
- Fixed a bug in initialization where the forcer's preferences weren't being loaded sometimes
- Added seeding at initialization for the random number generator to ensure a different experience every time
- Improved clothing state tracking/manipulation so the undress patterns consistently work
- Made state 5 circle back to 3 instead of 4 so it behaves as described in the readme
- Moved the 5->3 loop's probability threshold to a different channel so it doesn't interfere with the probabilities of individual states repeating
- Tweaked the probability threshold constants to adjust for the above changes
- Made sure the repeat counters for states 3 and 4 are reset upon leaving so their probability thresholds reset the next time they're entered

I don't think the clothing state changes are quite robust enough for the M->M/F->F cases (or if they even do the right thing for M->F and F->M), but the new behavior kind of made sense in the cases I tested.