### PR TITLE
POV tweaks

### DIFF
--- a/AAUnlimited/Files/Config.cpp
+++ b/AAUnlimited/Files/Config.cpp
@@ -12,7 +12,10 @@ const Config::MemberInfo Config::knownMembers[num_elements] = {
 	MemberInfo(Config::BOOL,	"bHAiOnNoPromptH", false),	//HAI_ON_NO_PROMPT
 	MemberInfo(Config::INT,		"savedEyeTextureUsage", 1),	//SAVED_EYE_TEXTURE_USAGE,	
 	MemberInfo(Config::INT,		"facelessMaleSlot", 90),	//FACELESS_SLOT_MALE,	
-	MemberInfo(Config::INT,		"facelessFemaleSlot", 7)	//FACELESS_SLOT_FEMALE
+	MemberInfo(Config::INT,		"facelessFemaleSlot", 7),	//FACELESS_SLOT_FEMALE
+	MemberInfo(Config::FLOAT,		"fPOVOffsetX", 0.0f),	//POV_OFFSET_X
+	MemberInfo(Config::FLOAT,		"fPOVOffsetY", 0.0f),	//POV_OFFSET_Y
+	MemberInfo(Config::FLOAT,		"fPOVOffsetZ", 0.0f)	//POV_OFFSET_Z
 };
 
 Config g_Config;

--- a/AAUnlimited/Files/Config.cpp
+++ b/AAUnlimited/Files/Config.cpp
@@ -10,7 +10,9 @@ const Config::MemberInfo Config::knownMembers[num_elements] = {
 	MemberInfo(Config::BOOL,	"bEnableFacecam", false), //USE_H_FACECAM
 	MemberInfo(Config::BOOL,	"bNoPromptHIsRape", false),	//NO_PROMPT_IS_FORCE
 	MemberInfo(Config::BOOL,	"bHAiOnNoPromptH", false),	//HAI_ON_NO_PROMPT
-	MemberInfo(Config::INT,		"savedEyeTextureUsage", 1)	//SAVED_EYE_TEXTURE_USAGE,	
+	MemberInfo(Config::INT,		"savedEyeTextureUsage", 1),	//SAVED_EYE_TEXTURE_USAGE,	
+	MemberInfo(Config::INT,		"facelessMaleSlot", 90),	//FACELESS_SLOT_MALE,	
+	MemberInfo(Config::INT,		"facelessFemaleSlot", 7)	//FACELESS_SLOT_FEMALE
 };
 
 Config g_Config;

--- a/AAUnlimited/Files/Config.h
+++ b/AAUnlimited/Files/Config.h
@@ -16,6 +16,8 @@ public:
 
 		FACELESS_SLOT_MALE, FACELESS_SLOT_FEMALE,
 
+		POV_OFFSET_X, POV_OFFSET_Y, POV_OFFSET_Z,
+
 		num_elements
 	};
 	union MemberData {

--- a/AAUnlimited/Files/Config.h
+++ b/AAUnlimited/Files/Config.h
@@ -14,6 +14,8 @@ public:
 
 		SAVED_EYE_TEXTURE_USAGE,
 
+		FACELESS_SLOT_MALE, FACELESS_SLOT_FEMALE,
+
 		num_elements
 	};
 	union MemberData {

--- a/AAUnlimited/Functions/AAPlay/Facecam.cpp
+++ b/AAUnlimited/Functions/AAPlay/Facecam.cpp
@@ -41,10 +41,10 @@ void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 	if (g_Config.GetKeyValue(Config::USE_H_FACECAM).bVal == false) return;
 	if (!notEnd) {
 		//prevent losing your heads
-		loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = m_activeFaceSlot;							//restore active's face slot
-		loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_activeHair);	//restore active's haircut
-		loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = m_passiveFaceSlot;							//restore passive's face slot
-		loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_passiveHair);	//restore passive's haircut
+		//loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = m_activeFaceSlot;							//restore active's face slot
+		//loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_activeHair);	//restore active's haircut
+		//loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = m_passiveFaceSlot;							//restore passive's face slot
+		//loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_passiveHair);	//restore passive's haircut
 
 		loc_state = 0;
 		loc_focusBone = NULL;

--- a/AAUnlimited/Functions/AAPlay/Facecam.cpp
+++ b/AAUnlimited/Functions/AAPlay/Facecam.cpp
@@ -7,6 +7,7 @@
 #include "External\ExternalClasses\HClasses\HInfo.h"
 #include "External\ExternalClasses\Bone.h"
 #include "General\ModuleInfo.h"
+#include "Files\Logger.h"
 
 /*
  * Here is the glorious plan (please dont laugh):
@@ -27,22 +28,52 @@ ExtClass::HInfo* loc_hinfo = NULL;
 ExtClass::Bone* loc_focusBone = NULL;
 int loc_state = 0;
 
+BYTE m_activeFaceSlot = BYTE(255);
+BYTE m_passiveFaceSlot = BYTE(255);
+
+ExtClass::CharacterData::Hair* m_activeHair = NULL;
+ExtClass::CharacterData::Hair* m_passiveHair = NULL;
+
 void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 	if (g_Config.GetKeyValue(Config::USE_H_FACECAM).bVal == false) return;
 	if (!notEnd) {
 		loc_state = 0;
 		loc_focusBone = NULL;
 		loc_hinfo = NULL;
+		if (m_passiveHair != NULL) {
+			delete m_passiveHair;
+			m_passiveHair == NULL;
+		}
+		if (m_activeHair != NULL) {
+			delete m_activeHair;
+			m_activeHair == NULL;
+		}
+		m_activeFaceSlot = BYTE(255);
+		m_passiveFaceSlot = BYTE(255);
 	}
 	else {
+		const BYTE faceMaleFaceless = 90;
+		ExtClass::CharacterData::Hair baldHaircut = ExtClass::CharacterData::Hair();
+			baldHaircut.frontHair = 0;
+			baldHaircut.sideHair = 0;
+			baldHaircut.backhair = 0;
+			baldHaircut.hairExtension = 0;
+		
 		loc_hinfo = hInfo;
+		//remember faces the first time
+		if (m_passiveFaceSlot == BYTE(255)) m_passiveFaceSlot = loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot;
+		if (m_activeFaceSlot == BYTE(255)) m_activeFaceSlot = loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot;
+		//remember hairstyles the first time
+		if (m_passiveHair == NULL) m_passiveHair = new ExtClass::CharacterData::Hair(loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair);
+		if (m_activeHair == NULL) m_activeHair = new ExtClass::CharacterData::Hair(loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair);
+
 		if (loc_state != 0) {
 
 			//we need to keep all camera parameters at 0 (except for fov of course)
 			ExtClass::HCamera* cam = hInfo->GetCamera();
 
-			cam->m_xRotRad = 0;
-			cam->m_yRotRad = M_PI;
+			//cam->m_xRotRad = 0;
+			//cam->m_yRotRad = M_PI;
 			cam->m_zRotRad = 0;
 
 			cam->m_distToMid = 0;
@@ -52,7 +83,9 @@ void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 			cam->m_zShift = 0;
 
 			//we align the camera with the bone by copying the matrix
-			cam->m_matrix = loc_focusBone->m_matrix2;
+			auto mat = loc_focusBone->m_matrix2;
+			mat._42 += 1;
+			cam->m_matrix = mat;
 
 			//*(BYTE*)(General::GameBase + 0x3A6C80) = 3; //whether the q button is pressed
 		}
@@ -63,13 +96,59 @@ void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 
 
 void AdjustCamera(ExtClass::Bone* bone) {
+	const BYTE faceMaleFaceless = 90;
+	ExtClass::CharacterData::Hair baldHaircut = ExtClass::CharacterData::Hair();
+		baldHaircut.frontHair = 0;
+		baldHaircut.sideHair = 0;
+		baldHaircut.backhair = 0;
+		baldHaircut.hairExtension = 0;
+
+
+	LOGPRIO(Logger::Priority::INFO) << bone->m_name << "\n";
 	if (loc_hinfo == NULL) return;
 	//make sure the q button was pressed, which means bone is the first bone of participant 2 (or 1 depending on position ._.)
-	if (bone != loc_hinfo->m_passiveParticipant->m_charPtr->m_bonePtrArray[0] 
-		&& bone != loc_hinfo->m_activeParticipant->m_charPtr->m_bonePtrArray[0]) return;
+	//	Q - toggles states
+	//	W - toggles head visibility depending on the state:
+	//		state 1 - passive's POV
+	//		state 2 - active's POV
+	//		state 3 - default camera
+	if (bone != loc_hinfo->m_passiveParticipant->m_charPtr->m_bonePtrArray[0]
+		&& bone != loc_hinfo->m_activeParticipant->m_charPtr->m_bonePtrArray[0]) {	//if not Q was pressed
 
-	//switch state
-	loc_state++;
+		if (bone == loc_hinfo->m_passiveParticipant->m_charPtr->m_bonePtrArray[1]
+			|| bone == loc_hinfo->m_activeParticipant->m_charPtr->m_bonePtrArray[1]) { //if W was pressed
+			
+			if (loc_state == 1) { //toggle passive
+				if (loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot != faceMaleFaceless) {			//if head is visible
+					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = faceMaleFaceless;				//set passive's face slot to faceless(male only for now)
+					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = baldHaircut;						//set passive's haircut to bald
+				} else {
+					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = m_passiveFaceSlot;	//restore passive's face slot
+					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_passiveHair);			//restore passive's haircut
+				}
+			} else if (loc_state == 2) { //toggle active
+				if (loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot != faceMaleFaceless) {			//if head is visible
+					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = faceMaleFaceless;				//set active's face slot to faceless(male only for now)
+					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = baldHaircut;						//set active's haircut to bald
+				} else {
+					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = m_activeFaceSlot;				//restore active's face slot
+					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_activeHair);			//restore active's haircut
+				}
+			} else { //restore both
+				loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = m_activeFaceSlot;				//restore active's face slot
+				loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_activeHair);			//restore active's haircut
+
+				loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = m_passiveFaceSlot;				//restore passive's face slot
+				loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_passiveHair);			//restore passive's haircut
+			}
+			return;
+		}
+		else return;
+	} else { //if Q was pressed
+		//switch state
+		loc_state++;
+	}
+
 	if (loc_state == 3) {
 		//if we come back to free camera mode, restore the matrix to an identity matrix
 		loc_state = 0;
@@ -80,6 +159,7 @@ void AdjustCamera(ExtClass::Bone* bone) {
 											0,0,0,1.0f
 										};
 		loc_hinfo->GetCamera()->m_matrix = idMatr;
+
 	}
 
 	//set bone depending on state

--- a/AAUnlimited/Functions/AAPlay/Facecam.cpp
+++ b/AAUnlimited/Functions/AAPlay/Facecam.cpp
@@ -40,6 +40,12 @@ ExtClass::CharacterData::Hair* m_passiveHair = NULL;
 void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 	if (g_Config.GetKeyValue(Config::USE_H_FACECAM).bVal == false) return;
 	if (!notEnd) {
+		//prevent losing your heads
+		loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = m_activeFaceSlot;							//restore active's face slot
+		loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_activeHair);	//restore active's haircut
+		loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = m_passiveFaceSlot;							//restore passive's face slot
+		loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_passiveHair);	//restore passive's haircut
+
 		loc_state = 0;
 		loc_focusBone = NULL;
 		loc_hinfo = NULL;

--- a/AAUnlimited/Functions/AAPlay/Facecam.cpp
+++ b/AAUnlimited/Functions/AAPlay/Facecam.cpp
@@ -28,6 +28,9 @@ ExtClass::HInfo* loc_hinfo = NULL;
 ExtClass::Bone* loc_focusBone = NULL;
 int loc_state = 0;
 
+BYTE facelessSlotMale = 90;	//if default fails us set it to something
+BYTE facelessSlotFemale = 7;
+
 BYTE m_activeFaceSlot = BYTE(255);
 BYTE m_passiveFaceSlot = BYTE(255);
 
@@ -51,14 +54,7 @@ void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 		m_activeFaceSlot = BYTE(255);
 		m_passiveFaceSlot = BYTE(255);
 	}
-	else {
-		const BYTE faceMaleFaceless = 90;
-		ExtClass::CharacterData::Hair baldHaircut = ExtClass::CharacterData::Hair();
-			baldHaircut.frontHair = 0;
-			baldHaircut.sideHair = 0;
-			baldHaircut.backhair = 0;
-			baldHaircut.hairExtension = 0;
-		
+	else {		
 		loc_hinfo = hInfo;
 		//remember faces the first time
 		if (m_passiveFaceSlot == BYTE(255)) m_passiveFaceSlot = loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot;
@@ -66,14 +62,17 @@ void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 		//remember hairstyles the first time
 		if (m_passiveHair == NULL) m_passiveHair = new ExtClass::CharacterData::Hair(loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair);
 		if (m_activeHair == NULL) m_activeHair = new ExtClass::CharacterData::Hair(loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair);
+		//remember the empty face slots
+		facelessSlotMale = (BYTE)g_Config.GetKeyValue(Config::FACELESS_SLOT_MALE).iVal;
+		facelessSlotFemale = (BYTE)g_Config.GetKeyValue(Config::FACELESS_SLOT_FEMALE).iVal;
 
 		if (loc_state != 0) {
 
 			//we need to keep all camera parameters at 0 (except for fov of course)
 			ExtClass::HCamera* cam = hInfo->GetCamera();
 
-			//cam->m_xRotRad = 0;
-			//cam->m_yRotRad = M_PI;
+			//only roll should be fixed
+			//the rest of rotations can be controlled with the mouse to look around
 			cam->m_zRotRad = 0;
 
 			cam->m_distToMid = 0;
@@ -84,7 +83,8 @@ void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 
 			//we align the camera with the bone by copying the matrix
 			auto mat = loc_focusBone->m_matrix2;
-			mat._42 += 1;
+			mat._42 += 1;	//slight adjustment so that the partner looks vaguely in to the camera and not above
+			//mat._43 += 1;	//TODO: possibly adjust position so that the pivot is right between the eyes instead of inside the head
 			cam->m_matrix = mat;
 
 			//*(BYTE*)(General::GameBase + 0x3A6C80) = 3; //whether the q button is pressed
@@ -96,15 +96,15 @@ void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 
 
 void AdjustCamera(ExtClass::Bone* bone) {
-	const BYTE faceMaleFaceless = 90;
+	const BYTE facelessSlotActive = (loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_gender) ? facelessSlotFemale : facelessSlotMale;
+	const BYTE facelessSlotPassive = (loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_gender) ? facelessSlotFemale : facelessSlotMale;
+
 	ExtClass::CharacterData::Hair baldHaircut = ExtClass::CharacterData::Hair();
 		baldHaircut.frontHair = 0;
 		baldHaircut.sideHair = 0;
 		baldHaircut.backhair = 0;
 		baldHaircut.hairExtension = 0;
-
-
-	LOGPRIO(Logger::Priority::INFO) << bone->m_name << "\n";
+		
 	if (loc_hinfo == NULL) return;
 	//make sure the q button was pressed, which means bone is the first bone of participant 2 (or 1 depending on position ._.)
 	//	Q - toggles states
@@ -119,27 +119,31 @@ void AdjustCamera(ExtClass::Bone* bone) {
 			|| bone == loc_hinfo->m_activeParticipant->m_charPtr->m_bonePtrArray[1]) { //if W was pressed
 			
 			if (loc_state == 1) { //toggle passive
-				if (loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot != faceMaleFaceless) {			//if head is visible
-					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = faceMaleFaceless;				//set passive's face slot to faceless(male only for now)
+				if (loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot != facelessSlotPassive) {			//if head is visible
+					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = facelessSlotPassive;				//set passive's face slot to faceless(male only for now)
 					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = baldHaircut;						//set passive's haircut to bald
 				} else {
 					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = m_passiveFaceSlot;	//restore passive's face slot
 					loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_passiveHair);			//restore passive's haircut
 				}
+				//possibly reload the model
 			} else if (loc_state == 2) { //toggle active
-				if (loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot != faceMaleFaceless) {			//if head is visible
-					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = faceMaleFaceless;				//set active's face slot to faceless(male only for now)
+				if (loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot != facelessSlotActive) {			//if head is visible
+					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = facelessSlotActive;				//set active's face slot to faceless(male only for now)
 					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = baldHaircut;						//set active's haircut to bald
 				} else {
 					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = m_activeFaceSlot;				//restore active's face slot
 					loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_activeHair);			//restore active's haircut
 				}
+				//possibly reload the model
 			} else { //restore both
 				loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_faceSlot = m_activeFaceSlot;				//restore active's face slot
 				loc_hinfo->m_activeParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_activeHair);			//restore active's haircut
 
 				loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_faceSlot = m_passiveFaceSlot;				//restore passive's face slot
 				loc_hinfo->m_passiveParticipant->m_charPtr->m_charData->m_hair = ExtClass::CharacterData::Hair(*m_passiveHair);			//restore passive's haircut
+
+				//possibly reload the models
 			}
 			return;
 		}

--- a/AAUnlimited/Functions/AAPlay/Facecam.cpp
+++ b/AAUnlimited/Functions/AAPlay/Facecam.cpp
@@ -89,8 +89,9 @@ void PostTick(ExtClass::HInfo* hInfo, bool notEnd) {
 
 			//we align the camera with the bone by copying the matrix
 			auto mat = loc_focusBone->m_matrix2;
-			mat._42 += 1;	//slight adjustment so that the partner looks vaguely in to the camera and not above
-			//mat._43 += 1;	//TODO: possibly adjust position so that the pivot is right between the eyes instead of inside the head
+			mat._41 += g_Config.GetKeyValue(Config::POV_OFFSET_X).fVal;
+			mat._42 += g_Config.GetKeyValue(Config::POV_OFFSET_Y).fVal;	//slight adjustment so that the partner looks vaguely in to the camera and not above
+			mat._43 += g_Config.GetKeyValue(Config::POV_OFFSET_Z).fVal;	//TODO: possibly adjust position so that the pivot is right between the eyes instead of inside the head
 			cam->m_matrix = mat;
 
 			//*(BYTE*)(General::GameBase + 0x3A6C80) = 3; //whether the q button is pressed
@@ -109,6 +110,7 @@ void AdjustCamera(ExtClass::Bone* bone) {
 		baldHaircut.frontHair = 0;
 		baldHaircut.sideHair = 0;
 		baldHaircut.backhair = 0;
+		baldHaircut.backhairFlip = 1;
 		baldHaircut.hairExtension = 0;
 		
 	if (loc_hinfo == NULL) return;
@@ -153,7 +155,10 @@ void AdjustCamera(ExtClass::Bone* bone) {
 			}
 			return;
 		}
-		else return;
+		else {
+			LOGPRIO(Logger::Priority::INFO) << "Some other key was pressed\n";
+			return;
+		}
 	} else { //if Q was pressed
 		//switch state
 		loc_state++;


### PR DESCRIPTION
I'll apologize up front for shitty code - haven't touched C++ in a while.

* removed `X` and `Y` rotation locks form the camera so that you can look around;
* `Q` still toggles POVs: `default camera`->`passive actor`->`active actor`->`default camera`->...
+ `W` now toggles head visibility of selected actor(helps with clipping). The change will be visible only after the model reloads though. Can be forced by changing `dress state` or `sex position`;
 + Technically it doesn't remove the head - it just changes whatever face slot there was to the one listed in config as `facelessMaleSlot`/`facelessFemaleSlot`. For males it's `90` and for females it's undecided. I've set it as `7` because it's the first open spot according to the [google doc](https://docs.google.com/spreadsheets/d/1gwmoVpKuSuF0PtEPLEB17eK_dexPaKU106ShZEpBLhg/edit#gid=471115183);
 + Also sets hairstyle to be completely bald;
 + Pressing `W` again will return the selected actor's head to normal;
 + Pressing `W` while the camera is in `default mode` will return both heads to normal and center the pivot on the chest.
+ Camera position offsets can now be set in the config file. Use `fPOVOffsetX`, `fPOVOffsetY`, `fPOVOffsetZ`

What's left:
* when changing positions/POVs the default camera rotation faces the wrong way so it's easy to be disoriented.
* Implement proper safeguards from losing the heads after disabling them and exiting H. As it is user has to make sure everything's normal before quitting.
* adjusting pivot position with the arrow keys or something like that. Static offsets most likely wouldn't cut it because in some positions `X` and `Z` offsets apparently switch. One way to do it would be to propagate the key pressed down to `void AdjustCamera(ExtClass::Bone* bone)` and adjust camera position offset dynamically.
* eye/head tracking toggle maybe?
* fix occasional crashes
* testing

`AAUnlimitedDLL.dll` and `AAUnlimitedEXE.exe` for quick testing: [mega](https://mega.nz/#F!IZs3VY5b!axfi9mlecCwLDdvpvIIbzw)