### PR TITLE
Styles and Triggers

### DIFF
--- a/AAUnlimited/Functions/AAPlay/Globals.cpp
+++ b/AAUnlimited/Functions/AAPlay/Globals.cpp
@@ -1,4 +1,5 @@
 #include "StdAfx.h"
+#include "Files\PersistentStorage.h"
 
 using namespace Shared::Triggers;
 
@@ -43,6 +44,12 @@ void InitOnLoad() {
 		//throw init event
 		CardInitializeData data;
 		data.card = seat;
+
+		auto inst = &AAPlay::g_characters[seat];
+		auto storage = PersistentStorage::ClassStorage::getStorage(Shared::GameState::getCurrentClassSaveName());
+		if (storage.getCardInt(inst, L"m_currCardStyle").isValid)
+			inst->m_cardData.m_currCardStyle = storage.getCardInt(inst, L"m_currCardStyle").value;
+
 		ThrowEvent(&data);
 
 		// ditto for lua

--- a/AAUnlimited/Functions/Shared/Triggers/Actions.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Actions.cpp
@@ -551,12 +551,15 @@ namespace Shared {
 		void Thread::SwitchCardStyle(std::vector<Value>& params) {
 			int seat = params[0].iVal;
 			int newset = params[1].iVal;
-			if (!AAPlay::g_characters[seat].m_char) {
+			if (!AAPlay::g_characters[seat].IsValid()) {
 				LOGPRIO(Logger::Priority::WARN) << "[Trigger] Invalid card target; seat number " << seat << "\r\n";
 				return;
 			}
 			auto& aau = AAPlay::g_characters[seat].m_cardData;
 			aau.SwitchActiveCardStyle(newset, AAPlay::g_characters[seat].m_char->m_charData);
+
+			auto storage = PersistentStorage::ClassStorage::getStorage(Shared::GameState::getCurrentClassSaveName());
+			storage.storeCardInt(&AAPlay::g_characters[seat], L"m_currCardStyle", newset);
 		}
 
 		//int card, string keyname, int value

--- a/AAUnlimited/Functions/Shared/Triggers/Expressions.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Expressions.cpp
@@ -1555,7 +1555,7 @@ namespace Shared {
 				{
 					56, EXPRCAT_GENERAL,
 					TEXT("Find Seat"), TEXT("Seat( %p )"), TEXT("Find a character with the provided full name(last name first name). Returns -1 if no such character is found"),
-					{ TYPE_INT }, (TYPE_INT),
+					{ TYPE_STRING }, (TYPE_INT),
 					&Thread::FindSeat
 				},
 				{


### PR DESCRIPTION
Current Style is now stored in the save.json. Unintentional consequence: you can switch body data and aau data separately with triggers if you edit the `m_currCardStyle` entry directly. Probably gonna keep it that way.
Triggers: small bugfix that broke the previously shared Voyeur traits