### PR TITLE
1.05

### DIFF
--- a/AAUnlimited/Files/PersistentStorage.cpp
+++ b/AAUnlimited/Files/PersistentStorage.cpp
@@ -212,3 +212,7 @@ PersistentStorage::ClassStorage PersistentStorage::ClassStorage::getStorage(std:
 	}
 	return PersistentStorage::ClassStorage::allStorages[file];
 }
+void PersistentStorage::ClassStorage::reset(std::wstring file)
+{
+	PersistentStorage::ClassStorage::allStorages.erase(file);
+}

--- a/AAUnlimited/Files/PersistentStorage.h
+++ b/AAUnlimited/Files/PersistentStorage.h
@@ -43,6 +43,7 @@ namespace PersistentStorage {
 		Option<picojson::object> getCardObject(CharInstData* character, std::wstring key);
 
 		static ClassStorage getStorage(std::wstring file);
+		static void reset(std::wstring file);
 		ClassStorage save();
 		
 		ClassStorage() {}

--- a/AAUnlimited/Functions/AAPlay/GameState.h
+++ b/AAUnlimited/Functions/AAPlay/GameState.h
@@ -59,9 +59,18 @@ namespace Shared {
 		void setConversationCharacter(ExtClass::CharacterStruct * chara, int idx);
 		void clearConversationCharacter(int idx);
 
-		inline ExtClass::CharacterStruct * getPlayerCharacter()
+		inline CharInstData* getPlayerCharacter()
 		{
-			return *(ExtVars::AAPlay::PlayerCharacterPtr());
+			ExtClass::CharacterStruct* pcPtr = *(ExtVars::AAPlay::PlayerCharacterPtr());
+			if (pcPtr != nullptr) {
+				for (int i = 0; i< 25; i++)
+				{
+					if (AAPlay::g_characters[i].m_char == pcPtr) return &AAPlay::g_characters[i];
+				}
+				return NULL;
+			}
+			else return NULL;
+			
 		}
 		void setPlayerCharacter(int seat);
 

--- a/AAUnlimited/Functions/AAPlay/Globals.cpp
+++ b/AAUnlimited/Functions/AAPlay/Globals.cpp
@@ -21,6 +21,7 @@ void InitOnLoad() {
 	ExtClass::CharacterStruct** start = ExtVars::AAPlay::ClassMembersArray();
 	ExtClass::CharacterStruct** end = ExtVars::AAPlay::ClassMembersArrayEnd();
 	int idxCharacter = 0;
+	PersistentStorage::ClassStorage::reset(Shared::GameState::getCurrentClassSaveName());
 	for(start; start != end; start++, idxCharacter++) {
 		ExtClass::CharacterStruct* it = *start;
 

--- a/AAUnlimited/Functions/AAPlay/HAi.cpp
+++ b/AAUnlimited/Functions/AAPlay/HAi.cpp
@@ -86,7 +86,7 @@ void ConversationTickPost(ExtClass::NpcPcNonInteractiveConversationStruct* param
 
 void ConversationPcResponse(ExtClass::BaseConversationStruct* param) { //sets PC response to yes and sets the bool that starts h-ai
 	if (loc_isTalkedTo) {
-		auto pc = Shared::GameState::getPlayerCharacter();
+		auto pc = Shared::GameState::getPlayerCharacter()->m_char;
 		int card = pc->m_seat;
 		CharInstData* cardInst = &AAPlay::g_characters[card];
 		if (cardInst->m_char->m_charData->m_traitBools[Trait::TRAIT_EXPLOITABLE]) {

--- a/AAUnlimited/Functions/Shared/Triggers/Actions.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Actions.cpp
@@ -1323,7 +1323,7 @@ namespace Shared {
 			*interrupt = 1;
 
 			//save the original PC and its target
-			GameState::setVoyeur(GameState::getPlayerCharacter());
+			GameState::setVoyeur(GameState::getPlayerCharacter()->m_char);
 			GameState::setVoyeurTarget(GameState::getVoyeur()->m_npcData->m_target);
 			GameState::setIsPeeping(true);
 

--- a/AAUnlimited/Functions/Shared/Triggers/Event.h
+++ b/AAUnlimited/Functions/Shared/Triggers/Event.h
@@ -244,7 +244,6 @@ namespace Triggers {
 		
 	EDC_DECLARE(RoomChangeData, ROOM_CHANGE)
 
-		int prevRoom;
 		int roomTarget;
 		int action;
 		int convotarget;

--- a/AAUnlimited/Functions/Shared/Triggers/Expressions.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Expressions.cpp
@@ -18,11 +18,11 @@ namespace Shared {
 		Value Thread::GetTriggeringCard(std::vector<Value>&) {
 			switch (this->eventData->GetId()) {
 			case KEY_PRESS:
-				return Shared::GameState::getPlayerCharacter()->m_seat;
+				return Shared::GameState::getPlayerCharacter()->m_char->m_seat;
 			case HPOSITION_CHANGE:
-				return Shared::GameState::getPlayerCharacter()->m_seat;
+				return Shared::GameState::getPlayerCharacter()->m_char->m_seat;
 			case H_END:
-				return Shared::GameState::getPlayerCharacter()->m_seat;
+				return Shared::GameState::getPlayerCharacter()->m_char->m_seat;
 			default:
 				return this->eventData->card;
 			}
@@ -62,8 +62,14 @@ namespace Shared {
 		}
 
 		Value Thread::GetPC(std::vector<Value>&) {
-			auto pc = Shared::GameState::getPlayerCharacter();
-			return pc->m_seat;
+			if (Shared::GameState::getPlayerCharacter() != nullptr) {
+				auto pc = Shared::GameState::getPlayerCharacter()->m_char;
+				if (pc != nullptr) {
+					return pc->m_seat;
+				}
+				else return -1;
+			}
+			else return -1;
 		}
 
 		//bool (int)
@@ -1283,18 +1289,22 @@ namespace Shared {
 
 		//int(int)
 		Value Thread::PCTalkAbout(std::vector<Value>& params) {
-			auto pc = Shared::GameState::getPlayerCharacter();
-			int seat = pc->m_seat;
-			if (ExpressionSeatInvalid(seat)) return Value(-1);
-			CharInstData* inst = &AAPlay::g_characters[seat];
-			if (!inst->IsValid() || inst->m_char->m_characterStatus->m_npcStatus->m_refto == nullptr)
-			{
-				return -1;
+			auto ptr = Shared::GameState::getPlayerCharacter();
+			if (ptr != nullptr) {
+				auto pc = ptr->m_char;
+				int seat = pc->m_seat;
+				if (ExpressionSeatInvalid(seat)) return Value(-1);
+				CharInstData* inst = &AAPlay::g_characters[seat];
+				if (!inst->IsValid() || inst->m_char->m_characterStatus->m_npcStatus->m_refto == nullptr)
+				{
+					return -1;
+				}
+				else
+				{
+					return Value((int)inst->m_char->m_characterStatus->m_npcStatus->m_refto->m_thisChar->m_seat);
+				}
 			}
-			else
-			{
-				return Value((int)inst->m_char->m_characterStatus->m_npcStatus->m_refto->m_thisChar->m_seat);
-			}
+			else return -1;
 		}
 
 		//string(int)
@@ -1986,12 +1996,7 @@ namespace Shared {
 		}
 		//int()
 		Value Thread::GetEventPreviousRoom(std::vector<Value>& params) {
-			switch (this->eventData->GetId()) {
-			case ROOM_CHANGE:
-				return ((RoomChangeData*)eventData)->prevRoom;
-			default:
-				return -1;
-			}
+			return -1;
 		}
 
 		//int()
@@ -2853,7 +2858,7 @@ namespace Shared {
 				},
 				{
 					99, EXPRCAT_EVENT,
-					TEXT("Room - Previous Room"), TEXT("PreviousRoom"), TEXT("For Room Changed event return the previous room"),
+					TEXT("INVALID"), TEXT("INVALID"), TEXT("This expression is invalid and is only a placeholder for the future."),
 					{}, (TYPE_INT),
 					&Thread::GetEventPreviousRoom
 				},

--- a/AAUnlimited/Functions/Shared/Triggers/Thread.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Thread.cpp
@@ -34,13 +34,13 @@ void Thread::ExecuteTrigger(Trigger* trg) {
 	//execute actions
 	CharInstData* triggeringCardInstance = &AAPlay::g_characters[this->eventData->card];
 	CharInstData* thisCardInstance = &AAPlay::g_characters[execTrigger->owningCard];
-	Shared::Triggers::triggers_log[Shared::Triggers::triggers_idxLog] = "Trigger [" + General::CastToString(execTrigger->name) + "]" + "\tThis card: [" + std::to_string(thisCardInstance->m_char->m_seat) + "]" + "\tTriggering card: [" + std::to_string(triggeringCardInstance->m_char->m_seat) + "]\r\n";
-	Shared::Triggers::triggers_idxLog = (Shared::Triggers::triggers_idxLog + 1) % 100;
 	//triggers_log[idxLog] = "Trigger [" <<  execTrigger->name << "]" << "\tThis card: [" << std::to_string(thisCardInstance->m_char->m_seat) <<  "]" << "\tTriggering card: [" << std::to_string(triggeringCardInstance->m_char->m_seat) << "]\r\n";
 
 	for(ip = 0; ip < trg->actions.size() && !execFinished; ip++) {
 		//get action
 		auto& action = trg->actions[ip];
+		Shared::Triggers::triggers_log[Shared::Triggers::triggers_idxLog] = "Trigger [" + General::CastToString(execTrigger->name) + "]" + "\tThis card: [" + std::to_string(thisCardInstance->m_char->m_seat) + "]" + "\tTriggering card: [" + std::to_string(triggeringCardInstance->m_char->m_seat) + "]"+ "\tAction: " + General::CastToString(action.action->name) +"\r\n";
+		Shared::Triggers::triggers_idxLog = (Shared::Triggers::triggers_idxLog + 1) % 100;
 		ExecuteAction(action);
 		if(executeCount > maxExecuteCount) {
 			return;

--- a/AAUnlimited/Functions/Shared/Triggers/Thread.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Thread.cpp
@@ -34,13 +34,13 @@ void Thread::ExecuteTrigger(Trigger* trg) {
 	//execute actions
 	CharInstData* triggeringCardInstance = &AAPlay::g_characters[this->eventData->card];
 	CharInstData* thisCardInstance = &AAPlay::g_characters[execTrigger->owningCard];
+	Shared::Triggers::triggers_log[Shared::Triggers::triggers_idxLog] = "Trigger [" + General::CastToString(execTrigger->name) + "]" + "\tThis card: [" + std::to_string(thisCardInstance->m_char->m_seat) + "]" + "\tTriggering card: [" + std::to_string(triggeringCardInstance->m_char->m_seat) + "]\r\n";
+	Shared::Triggers::triggers_idxLog = (Shared::Triggers::triggers_idxLog + 1) % 100;
+	//triggers_log[idxLog] = "Trigger [" <<  execTrigger->name << "]" << "\tThis card: [" << std::to_string(thisCardInstance->m_char->m_seat) <<  "]" << "\tTriggering card: [" << std::to_string(triggeringCardInstance->m_char->m_seat) << "]\r\n";
 
-
-	LOGPRIO(Logger::Priority::SPAM) << "Trigger [" <<  execTrigger->name << "]" << "\tThis card: [" << std::string(thisCardInstance->m_char->m_charData->m_forename) << " " << std::string(thisCardInstance->m_char->m_charData->m_surname) << "]" << "\tTriggering card: [" << std::string(triggeringCardInstance->m_char->m_charData->m_forename) << " " << std::string(triggeringCardInstance->m_char->m_charData->m_surname) << "]\r\n";
 	for(ip = 0; ip < trg->actions.size() && !execFinished; ip++) {
 		//get action
 		auto& action = trg->actions[ip];
-		LOGPRIONC(Logger::Priority::SPAM) " - " << action.action->name << "\r\n";
 		ExecuteAction(action);
 		if(executeCount > maxExecuteCount) {
 			return;

--- a/AAUnlimited/Functions/Shared/Triggers/Triggers.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Triggers.cpp
@@ -5,6 +5,8 @@
 
 namespace Shared {
 namespace Triggers {
+	std::string triggers_log[100];
+	int triggers_idxLog = 0;
 
 namespace {
 	int CalculateJumpDistance(int jumpAction, int jumpTo) {

--- a/AAUnlimited/Functions/Shared/Triggers/Triggers.h
+++ b/AAUnlimited/Functions/Shared/Triggers/Triggers.h
@@ -18,6 +18,8 @@
 
 namespace Shared {
 namespace Triggers {
+	extern std::string triggers_log[100];
+	extern int triggers_idxLog;
 
 	/*
 	 * A Variable type.

--- a/AAUnlimited/MemMods/AAPlay/Events/HInjections.cpp
+++ b/AAUnlimited/MemMods/AAPlay/Events/HInjections.cpp
@@ -32,6 +32,7 @@ bool __stdcall TickRedirect(ExtClass::HInfo* hInfo) {
 			LOGPRIO(Logger::Priority::INFO) << "H ended\n";
 			LUA_EVENT_NORET("end_h", hInfo);
 			Shared::Triggers::HEndData data;
+			data.card = Shared::GameState::getPlayerCharacter()->m_char->m_seat;
 			Shared::Triggers::ThrowEvent(&data);
 			
 		}

--- a/AAUnlimited/MemMods/AAPlay/Events/NpcActions.cpp
+++ b/AAUnlimited/MemMods/AAPlay/Events/NpcActions.cpp
@@ -275,6 +275,48 @@ void RoomChangeInjection() {
 		NULL);
 }
 
+void __stdcall hPositionChange(BYTE param) {
+	const DWORD offsetdom[]{ 0x3761CC, 0x28, 0x38, 0xe0, 0x6c, 0xe0, 0x00, 0x3c };
+	DWORD* actor0 = (DWORD*)ExtVars::ApplyRule(offsetdom);
+
+	const DWORD offsetsub[]{ 0x3761CC, 0x28, 0x38, 0xe0, 0x6c, 0xe4, 0x00, 0x3c };
+	DWORD* actor1 = (DWORD*)ExtVars::ApplyRule(offsetsub);
+
+	if (actor0 && actor1) {
+		Shared::Triggers::HPositionData hPositionData;
+		hPositionData.card = Shared::GameState::getPlayerCharacter()->m_char->m_seat;
+		hPositionData.actor0 = *actor0;
+		hPositionData.actor1 = *actor1;
+		hPositionData.position = param;
+		Shared::Triggers::ThrowEvent(&hPositionData);
+	}
+}
+
+
+void __declspec(naked) hPositionChangeRedirect() {
+	__asm {
+		pushad
+		push esi
+		call hPositionChange
+		popad
+		//original code
+		mov [edi + 0x000005F4], esi
+		ret
+	}
+}
+
+void hPositionChangeInjection() {
+	//roomID is in esi
+	//AA2Play.exe + 8197F - 89 B7 F4050000 - mov[edi + 000005F4], esi
+
+
+	DWORD address = General::GameBase + 0x8197F;
+	DWORD redirectAddress = (DWORD)(&hPositionChangeRedirect);
+	Hook((BYTE*)address,
+	{ 0x89, 0xB7, 0xF4, 0x05, 0x00, 0x00 },						//expected values
+		{ 0xE8, HookControl::RELATIVE_DWORD, redirectAddress, 0x90 },	//redirect to our function
+		NULL);
+}
 
 #if !NEW_HOOK
 DWORD __stdcall NpcAnswerEvent2(bool result, CharacterActivity* answerChar, CharacterActivity* askingChar)

--- a/AAUnlimited/MemMods/AAPlay/Events/NpcActions.cpp
+++ b/AAUnlimited/MemMods/AAPlay/Events/NpcActions.cpp
@@ -306,7 +306,7 @@ void __declspec(naked) hPositionChangeRedirect() {
 }
 
 void hPositionChangeInjection() {
-	//roomID is in esi
+	//H Position ID is in esi
 	//AA2Play.exe + 8197F - 89 B7 F4050000 - mov[edi + 000005F4], esi
 
 

--- a/AAUnlimited/MemMods/AAPlay/Events/NpcActions.h
+++ b/AAUnlimited/MemMods/AAPlay/Events/NpcActions.h
@@ -12,6 +12,7 @@ namespace NpcActions {
 	void NpcAnswerInjection();
 	void NpcMovingActionInjection();
 	void NpcMovingActionPlanInjection();
+	void RoomChangeInjection();
 
 #pragma pack(push, 1)
 	struct AnswerStruct {

--- a/AAUnlimited/MemMods/AAPlay/Events/NpcActions.h
+++ b/AAUnlimited/MemMods/AAPlay/Events/NpcActions.h
@@ -13,6 +13,7 @@ namespace NpcActions {
 	void NpcMovingActionInjection();
 	void NpcMovingActionPlanInjection();
 	void RoomChangeInjection();
+	void hPositionChangeInjection();
 
 #pragma pack(push, 1)
 	struct AnswerStruct {

--- a/AAUnlimited/MemMods/AAPlay/Events/PcConversation.cpp
+++ b/AAUnlimited/MemMods/AAPlay/Events/PcConversation.cpp
@@ -19,13 +19,23 @@ void __stdcall StartEvent() {
 }
 
 void __stdcall EndEvent() {
-	Shared::GameState::setIsPcConversation(false);
-	pcConvoStateUpdatedData.state = -1;
-	LUA_EVENT_NORET("convo", false);
-	Shared::Triggers::ThrowEvent(&pcConvoStateUpdatedData);
 
-	Shared::GameState::clearConversationCharacter(-1);
-	Poser::EndEvent();
+	//Event data carries over from the other event throw. This one is for PC conversation end, while stuff like pcConvoStateUpdatedData.card, pcConvoStateUpdatedData.action etc is set from the hook.
+	if (pcConvoStateUpdatedData.substruct != nullptr) {
+		if (&AAPlay::g_characters[pcConvoStateUpdatedData.card] != nullptr) {
+			if (&AAPlay::g_characters[pcConvoStateUpdatedData.card] != nullptr) {
+				if ((&AAPlay::g_characters[pcConvoStateUpdatedData.card])->IsValid()) {
+					Shared::GameState::setIsPcConversation(false);
+					pcConvoStateUpdatedData.state = -1;
+					LUA_EVENT_NORET("convo", false);
+					Shared::Triggers::ThrowEvent(&pcConvoStateUpdatedData);
+
+					Shared::GameState::clearConversationCharacter(-1);
+					Poser::EndEvent();
+				}
+			}
+		}
+	}
 }
 
 

--- a/AAUnlimited/MemMods/AAPlay/Events/PcConversation.cpp
+++ b/AAUnlimited/MemMods/AAPlay/Events/PcConversation.cpp
@@ -50,7 +50,7 @@ void __stdcall GeneralPreTick(ExtClass::MainConversationStruct* param) {
 		pcConvoStateUpdatedData.pc_response = (substruct->m_playerAnswer < arbitraryMaxResponse) ? substruct->m_playerAnswer : -1;
 		pcConvoStateUpdatedData.action = substruct->m_conversationId;
 		pcConvoStateUpdatedData.m_bStartH = &(substruct->m_bStartH);
-		pcConvoStateUpdatedData.card = (Shared::GameState::getPlayerCharacter())->m_seat;
+		pcConvoStateUpdatedData.card = (Shared::GameState::getPlayerCharacter())->m_char->m_seat;
 		pcConvoStateUpdatedData.conversationAnswerId = substruct->m_conversationAnswerId;
 		pcConvoStateUpdatedData.currentlyAnswering = substruct->m_bCurrentlyAnswering;
 		LUA_EVENT_NORET("convo_state_update", pcConvoStateUpdatedData.state);
@@ -67,7 +67,7 @@ void __stdcall GeneralPreTick(ExtClass::MainConversationStruct* param) {
 		pcConvoLineUpdatedData.pc_response = (substruct->m_playerAnswer < arbitraryMaxResponse) ? substruct->m_playerAnswer : -1;
 		pcConvoLineUpdatedData.action = substruct->m_conversationId;
 		pcConvoLineUpdatedData.m_bStartH = &(substruct->m_bStartH);
-		pcConvoLineUpdatedData.card = (Shared::GameState::getPlayerCharacter())->m_seat;
+		pcConvoLineUpdatedData.card = (Shared::GameState::getPlayerCharacter()->m_char)->m_seat;
 		pcConvoLineUpdatedData.conversationAnswerId = substruct->m_conversationAnswerId;
 		pcConvoLineUpdatedData.currentlyAnswering = substruct->m_bCurrentlyAnswering;
 		LUA_EVENT_NORET("convo_line_update", substruct->m_conversationState);
@@ -128,7 +128,7 @@ void __stdcall PcAnswer(ExtClass::BaseConversationStruct* param) {
 
 	data.pc_response = (substruct->m_playerAnswer < arbitraryMaxResponse) ? substruct->m_playerAnswer : -1;
 	data.substruct = substruct;
-	data.card = Shared::GameState::getPlayerCharacter() ? Shared::GameState::getPlayerCharacter()->m_seat : -1;
+	data.card = Shared::GameState::getPlayerCharacter()->m_char ? Shared::GameState::getPlayerCharacter()->m_char->m_seat : -1;
 	Shared::Triggers::ThrowEvent(&data);
 	if (!data.forceResponse) {
 		HAi::ConversationPcResponse(param);
@@ -139,7 +139,7 @@ void __stdcall PcAnswer(ExtClass::BaseConversationStruct* param) {
 	if (data.absolute_response != -1) {
 		substruct->m_playerAnswer = data.absolute_response;
 	}
-	effective_data.card = Shared::GameState::getPlayerCharacter() ? Shared::GameState::getPlayerCharacter()->m_seat : -1;
+	effective_data.card = Shared::GameState::getPlayerCharacter()->m_char ? Shared::GameState::getPlayerCharacter()->m_char->m_seat : -1;
 	effective_data.substruct = substruct;
 	effective_data.effective_response = (substruct->m_playerAnswer < arbitraryMaxResponse) ? substruct->m_playerAnswer : -1;
 	Shared::Triggers::ThrowEvent(&effective_data);

--- a/AAUnlimited/MemMods/AAPlay/Events/PcConversation.cpp
+++ b/AAUnlimited/MemMods/AAPlay/Events/PcConversation.cpp
@@ -20,7 +20,7 @@ void __stdcall StartEvent() {
 
 void __stdcall EndEvent() {
 
-	//Event data carries over from the other event throw. This one is for PC conversation end, while stuff like pcConvoStateUpdatedData.card, pcConvoStateUpdatedData.action etc is set from the hook.
+	//Event data carries over from the other event throw. This one is for PC conversation end, while stuff like pcConvoStateUpdatedData.card, pcConvoStateUpdatedData.action etc is set from general tick.
 	if (pcConvoStateUpdatedData.substruct != nullptr) {
 		if (&AAPlay::g_characters[pcConvoStateUpdatedData.card] != nullptr) {
 			if (&AAPlay::g_characters[pcConvoStateUpdatedData.card] != nullptr) {

--- a/AAUnlimited/MemMods/Hook.cpp
+++ b/AAUnlimited/MemMods/Hook.cpp
@@ -305,6 +305,7 @@ void InitializeHooks() {
 		NpcActions::NpcAnswerInjection();
 		NpcActions::NpcMovingActionInjection();
 		NpcActions::NpcMovingActionPlanInjection();
+		NpcActions::RoomChangeInjection();
 		Time::PeriodChangeInjection();	//most likely PeriodChangeRedirect() needs fixing
 //		if (int(g_Config["FixLocale"]) > FixLocale::IsEmulated())
 //			FixLocale::PatchAA2Play();

--- a/AAUnlimited/MemMods/Hook.cpp
+++ b/AAUnlimited/MemMods/Hook.cpp
@@ -306,6 +306,7 @@ void InitializeHooks() {
 		NpcActions::NpcMovingActionInjection();
 		NpcActions::NpcMovingActionPlanInjection();
 		NpcActions::RoomChangeInjection();
+		NpcActions::hPositionChangeInjection();
 		Time::PeriodChangeInjection();	//most likely PeriodChangeRedirect() needs fixing
 //		if (int(g_Config["FixLocale"]) > FixLocale::IsEmulated())
 //			FixLocale::PatchAA2Play();

--- a/AAUnlimited/MemMods/Shared/Events/GameTick.cpp
+++ b/AAUnlimited/MemMods/Shared/Events/GameTick.cpp
@@ -40,37 +40,15 @@ void AddTimer(int when, void *fn) {
 }
 */
 
-void CheckRoomChange() {
 
-	for (int seat = 0; seat < 25; seat = seat + 1) {
-		auto roomValue = Shared::GameState::GetRoomNumber(seat);
-		CharInstData* instance = &AAPlay::g_characters[seat];
-		if (instance->IsValid()) {
-			if (instance->m_char != nullptr) {
-				if (instance->m_char->m_npcData != nullptr) {
-					if (instance->m_char->m_npcData->roomPtr != nullptr) {
-						auto roomID = *(((int*)instance->m_char->m_npcData->roomPtr) + 5);
-						if (roomValue != roomID) {
-							roomChangeData.action = instance->m_forceAction.conversationId;
-							roomChangeData.roomTarget = instance->m_forceAction.roomTarget;
-							if (instance->m_forceAction.target1 != nullptr) {
-								roomChangeData.convotarget = int(instance->m_forceAction.target1->m_thisChar);
-							}
-
-							roomChangeData.prevRoom = roomValue;
-							Shared::GameState::SetRoomNumber(seat, roomID);
-
-							roomChangeData.card = seat;
-							if (roomChangeData.prevRoom < 0) return;
-							Shared::Triggers::ThrowEvent(&roomChangeData);
-						}
-					}
-				}
-
-			}
+void ResetOnTitle() {
+	if (General::IsAAPlay) {
+		if (*(ExtVars::AAPlay::PlayerCharacterPtr()) == nullptr) {
+			for (int i = 0; i < 25; i++) AAPlay::g_characters[i].Reset();
 		}
 	}
 }
+
 
 void hPositionChange() {
 	auto hPositionValue = Shared::GameState::getHPosition();
@@ -88,6 +66,7 @@ void hPositionChange() {
 			if (actor0 && actor1) {
 				Shared::GameState::setHPosition(*hPosition);
 
+				hPositionData.card = Shared::GameState::getPlayerCharacter()->m_char->m_seat;
 				hPositionData.actor0 = *actor0;
 				hPositionData.actor1 = *actor1;
 
@@ -121,10 +100,11 @@ int __stdcall GameTick() {
 		}
 		else break;
 	}*/
+
 	if (g_Config.bTriggers) {
-		CheckRoomChange();
 		hPositionChange();
 	}
+	ResetOnTitle();
 	return orig_GameTick();
 }
 

--- a/AAUnlimited/MemMods/Shared/Events/GameTick.cpp
+++ b/AAUnlimited/MemMods/Shared/Events/GameTick.cpp
@@ -3,9 +3,6 @@
 
 namespace GameTick {
 
-Shared::Triggers::RoomChangeData roomChangeData;
-Shared::Triggers::HPositionData hPositionData;
-
 int (__stdcall *orig_MsgHandler)(void *ptr, MSG *msg);
 int (__stdcall *orig_GameTick)();
 
@@ -50,33 +47,6 @@ void ResetOnTitle() {
 }
 
 
-void hPositionChange() {
-	auto hPositionValue = Shared::GameState::getHPosition();
-	const DWORD offset[]{ 0x3761CC, 0x28, 0x38, 0x5F4 };
-	DWORD* hPosition = (DWORD*)ExtVars::ApplyRule(offset);
-	if (hPosition != nullptr) {
-		if (*hPosition != hPositionValue) {
-
-			const DWORD offsetdom[]{ 0x3761CC, 0x28, 0x38, 0xe0, 0x6c, 0xe0, 0x00, 0x3c };
-			DWORD* actor0 = (DWORD*)ExtVars::ApplyRule(offsetdom);
-
-			const DWORD offsetsub[]{ 0x3761CC, 0x28, 0x38, 0xe0, 0x6c, 0xe4, 0x00, 0x3c };
-			DWORD* actor1 = (DWORD*)ExtVars::ApplyRule(offsetsub);
-
-			if (actor0 && actor1) {
-				Shared::GameState::setHPosition(*hPosition);
-
-				hPositionData.card = Shared::GameState::getPlayerCharacter()->m_char->m_seat;
-				hPositionData.actor0 = *actor0;
-				hPositionData.actor1 = *actor1;
-
-				hPositionData.position = *hPosition;
-				Shared::Triggers::ThrowEvent(&hPositionData);
-			}
-		}
-	}
-}
-
 int __stdcall GameTick() {
 	if (tick == 0) {
 		first_now = GetTickCount();
@@ -101,9 +71,6 @@ int __stdcall GameTick() {
 		else break;
 	}*/
 
-	if (g_Config.bTriggers) {
-		hPositionChange();
-	}
 	ResetOnTitle();
 	return orig_GameTick();
 }

--- a/AAUnlimited/Script/ScriptLua.cpp
+++ b/AAUnlimited/Script/ScriptLua.cpp
@@ -365,10 +365,16 @@ void Lua::bindLua() {
 			LUA_EVENT(mstr, m->wParam, m->lParam, (DWORD)m->hwnd, m->pt.x, m->pt.y);
 			if (mstr == "keydown") {
 				if (General::IsAAPlay) {
-					keyPressData.keyVal = m->wParam;
-					Shared::Triggers::ThrowEvent(&keyPressData);
+					if (Shared::GameState::getPlayerCharacter() != nullptr) {
+						if (Shared::GameState::getPlayerCharacter()->IsValid()) {
+							keyPressData.card = Shared::GameState::getPlayerCharacter()->m_char->m_seat;
+							keyPressData.keyVal = m->wParam;
+							Shared::Triggers::ThrowEvent(&keyPressData);
+						}
+					}
 				}
 			}
+
 			if (m->wParam == -1)
 				return true;
 		}

--- a/AAUnlimited/Texts/init.lua
+++ b/AAUnlimited/Texts/init.lua
@@ -1,6 +1,6 @@
 require "debug"
 
-AAU_VERSION = "1.0.4 "
+AAU_VERSION = "1.0.5 "
 ---------------------------
 -- C++ interfacing globals
 ---------------------------

--- a/AAUnlimited/main.cpp
+++ b/AAUnlimited/main.cpp
@@ -129,6 +129,13 @@ static LONG WINAPI panic(EXCEPTION_POINTERS *exceptionInfo) {
 	if (hFile == INVALID_HANDLE_VALUE)
 		return EXCEPTION_CONTINUE_SEARCH;
 
+	for (int idx = 0; idx < 100; idx = idx + 1)
+	{
+		//Dump last triggers without slowing down the game
+		LOGPRIONC(Logger::Priority::INFO) Shared::Triggers::triggers_log[Shared::Triggers::triggers_idxLog];
+		Shared::Triggers::triggers_idxLog = (Shared::Triggers::triggers_idxLog + 1) % 100;
+
+	}
 	MINIDUMP_EXCEPTION_INFORMATION mdei;
 	mdei.ThreadId = GetCurrentThreadId();
 	mdei.ExceptionPointers = exceptionInfo;


### PR DESCRIPTION
* Safeguarded a bunch of actions that could crash the game under the wrong circumstances.
* Significantly improved game performance by hooking room-change event and h-position change event properly.
* Fixed modules lingering when you exit to main menu, which caused crashes.
* Fixed card storage not being nuked when you load the same save file twice.
* Removed trigger data logging on spam log priority. It is now written only when the game crashes.