### PR TITLE
Face Camera (POV) improvements and fixes

### DIFF
--- a/AAUnlimited/External/ExternalClasses/Camera.cpp
+++ b/AAUnlimited/External/ExternalClasses/Camera.cpp
@@ -62,21 +62,6 @@ int Camera::SetFocusBone(ExtClass::Frame* bone, double x, double y, double z, bo
 
 void Camera::InitPovParams(int stabilize_percents) {
 	stabilizeCoefficient = (float)stabilize_percents / 100;
-	// to unlock `Near clipping distance` - NOP some instructions
-	Hook((BYTE*)(General::GameBase + 0x80EA7), { 0xD9 }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EA8), { 0x1D }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EA9), { 0x78 }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EAA), { 0x85 }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EAB), { 0x56 }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EAC), { 0x00 }, { 0x90 }, NULL);
-	// to prevent random changes the FOV by game in H scenes - NOP some instructions
-	Hook((BYTE*)(General::GameBase + 0x80E9F), { 0xD9 }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EA0), { 0x1D }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EA1), { 0x74 }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EA2), { 0x85 }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EA3), { 0x56 }, { 0x90 }, NULL);
-	Hook((BYTE*)(General::GameBase + 0x80EA4), { 0x00 }, { 0x90 }, NULL);
-	// to unlock `Far clipping` use 0x80EB3 (or 0x80EAD)
 }
 
 }

--- a/AAUnlimited/External/ExternalClasses/Camera.cpp
+++ b/AAUnlimited/External/ExternalClasses/Camera.cpp
@@ -62,13 +62,20 @@ int Camera::SetFocusBone(ExtClass::Frame* bone, double x, double y, double z, bo
 
 void Camera::InitPovParams(int stabilize_percents) {
 	stabilizeCoefficient = (float)stabilize_percents / 100;
-	// to unlock `Near clipping distance` NOP some instructions
+	// to unlock `Near clipping distance` - NOP some instructions
 	Hook((BYTE*)(General::GameBase + 0x80EA7), { 0xD9 }, { 0x90 }, NULL);
 	Hook((BYTE*)(General::GameBase + 0x80EA8), { 0x1D }, { 0x90 }, NULL);
 	Hook((BYTE*)(General::GameBase + 0x80EA9), { 0x78 }, { 0x90 }, NULL);
 	Hook((BYTE*)(General::GameBase + 0x80EAA), { 0x85 }, { 0x90 }, NULL);
 	Hook((BYTE*)(General::GameBase + 0x80EAB), { 0x56 }, { 0x90 }, NULL);
 	Hook((BYTE*)(General::GameBase + 0x80EAC), { 0x00 }, { 0x90 }, NULL);
+	// to prevent random changes the FOV by game in H scenes - NOP some instructions
+	Hook((BYTE*)(General::GameBase + 0x80E9F), { 0xD9 }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EA0), { 0x1D }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EA1), { 0x74 }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EA2), { 0x85 }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EA3), { 0x56 }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EA4), { 0x00 }, { 0x90 }, NULL);
 	// to unlock `Far clipping` use 0x80EB3 (or 0x80EAD)
 }
 

--- a/AAUnlimited/External/ExternalClasses/Camera.cpp
+++ b/AAUnlimited/External/ExternalClasses/Camera.cpp
@@ -60,8 +60,16 @@ int Camera::SetFocusBone(ExtClass::Frame* bone, double x, double y, double z, bo
 	return 1;
 }
 
-void Camera::SetPovStabilization(int stabilize_percents) {
+void Camera::InitPovParams(int stabilize_percents) {
 	stabilizeCoefficient = (float)stabilize_percents / 100;
+	// to unlock `Near clipping distance` NOP some instructions
+	Hook((BYTE*)(General::GameBase + 0x80EA7), { 0xD9 }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EA8), { 0x1D }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EA9), { 0x78 }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EAA), { 0x85 }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EAB), { 0x56 }, { 0x90 }, NULL);
+	Hook((BYTE*)(General::GameBase + 0x80EAC), { 0x00 }, { 0x90 }, NULL);
+	// to unlock `Far clipping` use 0x80EB3 (or 0x80EAD)
 }
 
 }

--- a/AAUnlimited/External/ExternalClasses/Camera.h
+++ b/AAUnlimited/External/ExternalClasses/Camera.h
@@ -42,7 +42,7 @@ public:
 	}
 	static void PostTick(ExtClass::HInfo* hInfo, bool tickRetVal);
 	static int SetFocusBone(ExtClass::Frame* bone, double x, double y, double z, bool);
-
+	static void SetPovStabilization(int stabilize_percents);
 
 	D3DMATRIX m_matrix; //used, but typically identity matrix. can be used to distort view
 };

--- a/AAUnlimited/External/ExternalClasses/Camera.h
+++ b/AAUnlimited/External/ExternalClasses/Camera.h
@@ -42,7 +42,7 @@ public:
 	}
 	static void PostTick(ExtClass::HInfo* hInfo, bool tickRetVal);
 	static int SetFocusBone(ExtClass::Frame* bone, double x, double y, double z, bool);
-	static void SetPovStabilization(int stabilize_percents);
+	static void InitPovParams(int stabilize_percents);
 
 	D3DMATRIX m_matrix; //used, but typically identity matrix. can be used to distort view
 };

--- a/AAUnlimited/Script/ScriptLua.cpp
+++ b/AAUnlimited/Script/ScriptLua.cpp
@@ -307,6 +307,10 @@ void Lua::bindLua() {
 		Camera::SetFocusBone(s.get(1), s.get(2), s.get(3), s.get(4), s.get(5));
 	});
 
+	_BINDING["SetPovStabilization"] = LUA_LAMBDA0({
+		Camera::SetPovStabilization(s.get(1));
+	});
+
 	_BINDING["SetClassJSONData"] = LUA_LAMBDA({
 		std::string key((const char*)s.get(1));
 		std::string json((const char*)s.get(2));

--- a/AAUnlimited/Script/ScriptLua.cpp
+++ b/AAUnlimited/Script/ScriptLua.cpp
@@ -307,8 +307,8 @@ void Lua::bindLua() {
 		Camera::SetFocusBone(s.get(1), s.get(2), s.get(3), s.get(4), s.get(5));
 	});
 
-	_BINDING["SetPovStabilization"] = LUA_LAMBDA0({
-		Camera::SetPovStabilization(s.get(1));
+	_BINDING["InitPovParams"] = LUA_LAMBDA0({
+		Camera::InitPovParams(s.get(1));
 	});
 
 	_BINDING["SetClassJSONData"] = LUA_LAMBDA({

--- a/AAUnlimited/Texts/mod/facecam.lua
+++ b/AAUnlimited/Texts/mod/facecam.lua
@@ -349,8 +349,8 @@ function _M:load()
 	self.activate = self.activate or 'a'
 	self.reset = self.reset or 'qwer'
 	self.zunlock = self.zunlock or false
-	self.startfov = self.startfov or 0.9
-	facecamFOV = self.startfov
+	self.startfov = self.startfov or 90
+	facecamFOV = self.startfov / 100
 	self.amplitudemov = self.amplitudemov or 50
 	self.step = self.step or 0.05
 	self.tonguedef = self.tonguedef or false
@@ -377,7 +377,7 @@ function _M:config()
 Activate key: %s{alphanum key to enter facecam}
 Reset keys: %s{any of these keys reset facecam}
 Allow Roll (Z) axis: %b{Descent mode}
-Starting FOV: %r[0.1,1.5,0.1]{Field of view on Activating Facecam}
+Starting FOV, degrees: %r[10,150,5]{Field of view on Activating Facecam}
 Motion amplitude: %r[5,100,5]{How much will the camera follow head movements. Low values are recommended for greater stabilization}
 Offset step: %r[0.01,0.5,0.01]{Eye offset. Use Numpad Ins,Del,+,-,*,/}
 Show Tongue by default: %b{Show tongue for a managed character. Use Numpad 9 to toggle}
@@ -387,7 +387,7 @@ Show Tongue by default: %b{Show tongue for a managed character. Use Numpad 9 to 
 		self.reset = rkeys
 		self.zunlock = z == 1
 		self.startfov = stfov
-		facecamFOV = stfov
+		facecamFOV = stfov / 100
 		self.amplitudemov = amplitude
 		self.step = step
 		self.tonguedef = tonguedefault == 1

--- a/AAUnlimited/Texts/mod/facecam.lua
+++ b/AAUnlimited/Texts/mod/facecam.lua
@@ -44,7 +44,7 @@ local eye = nil
 local center = {x=0,y=0,z=0}
 local xyz
 local normalCamera = {rotx=0,roty=0,rotz=0,rotdist=0,fov=0.5}
-local facecamFOV = 1
+local facecamFOV = 0.5
 local prevPosId = 0
 
 --local
@@ -292,6 +292,8 @@ function on.launch() -- Sending Motion amplitude to Camera
 		amplitudeval = math.ceil(100 - math.sqrt(9050 - mcfg.amplitudemov^2))
 	end
 	InitPovParams(amplitudeval)
+	-- to unlock `Near clipping distance` and prevent random changes the FOV by game in H scenes
+	if exe_type == "play" then g_poke(0x80E9B, "\xEB\x10") end 
 end
 
 --[[function on.hipoly()
@@ -347,7 +349,7 @@ function _M:load()
 	self.activate = self.activate or 'a'
 	self.reset = self.reset or 'qwer'
 	self.zunlock = self.zunlock or false
-	self.startfov = self.startfov or 1.2
+	self.startfov = self.startfov or 0.5
 	facecamFOV = self.startfov
 	self.amplitudemov = self.amplitudemov or 30
 	self.step = self.step or 0.05

--- a/AAUnlimited/Texts/mod/facecam.lua
+++ b/AAUnlimited/Texts/mod/facecam.lua
@@ -44,7 +44,7 @@ local eye = nil
 local center = {x=0,y=0,z=0}
 local xyz
 local normalCamera = {rotx=0,roty=0,rotz=0,rotdist=0,fov=0.5}
-local facecamFOV = 0.5
+local facecamFOV = 0.9
 local prevPosId = 0
 
 --local
@@ -349,9 +349,9 @@ function _M:load()
 	self.activate = self.activate or 'a'
 	self.reset = self.reset or 'qwer'
 	self.zunlock = self.zunlock or false
-	self.startfov = self.startfov or 0.5
+	self.startfov = self.startfov or 0.9
 	facecamFOV = self.startfov
-	self.amplitudemov = self.amplitudemov or 30
+	self.amplitudemov = self.amplitudemov or 50
 	self.step = self.step or 0.05
 	self.tonguedef = self.tonguedef or false
 	def.tongue = self.tonguedef and 0 or 2

--- a/AAUnlimited/Texts/mod/facecam.lua
+++ b/AAUnlimited/Texts/mod/facecam.lua
@@ -238,6 +238,15 @@ function on.start_h(hi)
 	parts[2] = hinfo.m_passiveParticipant.m_charPtr
 end
 
+function on.launch() -- Sending Motion amplitude to Camera
+	local amplitudeval
+	if mcfg.amplitudemov > 95 then 
+		amplitudeval = mcfg.amplitudemov
+	else
+		amplitudeval = math.ceil(100 - math.sqrt(9050 - mcfg.amplitudemov^2))
+	end
+	SetPovStabilization(amplitudeval)
+end
 
 --[[function on.hipoly()
 	if not hinfo then return end
@@ -286,6 +295,7 @@ function _M:load()
 	self.zunlock = self.zunlock or false
 	self.step = self.step or 0.05
 	self.startfov = self.startfov or 1.2
+	self.amplitudemov = self.amplitudemov or 30
 	-- tu, hackanon
 	orig_hook = g_hook_vptr(0x326FC4, 1, function(orig, this, arg)
 		arg = on_hposchange(arg)
@@ -304,18 +314,20 @@ end
 function _M:config()
 	require "iuplua"
 	require "iupluacontrols"
-	local okay, akey, rkeys, z, stfov, step = iup.GetParam("Configure Facecam", nil, [[
+	local okay, akey, rkeys, z, stfov, amplitude, step = iup.GetParam("Configure Facecam", nil, [[
 Activate key: %s{alphanum key to enter facecam}
 Reset keys: %s{any of these keys reset facecam}
 Allow Roll (Z) axis: %b{Descent mode}
 Starting FOV: %r[0.1,1.5,0.1]{Field of view on Activating Facecam}
+Motion amplitude: %r[5,100,5]{How much will the camera follow head movements. Low values are recommended for greater stabilization}
 Offset step: %r[0.01,0.5,0.01]{Eye offset. Use numpad Ins,Del,+,-,*,/}
-]], self.activate, self.reset, self.zunlock and 1 or 0, self.startfov, self.step)
+]], self.activate, self.reset, self.zunlock and 1 or 0, self.startfov, self.amplitudemov, self.step)
 	if okay then
 		self.activate = akey
 		self.reset = rkeys
 		self.zunlock = z == 1
 		self.startfov = stfov
+		self.amplitudemov = amplitude
 		self.step = step
 		set_status(current)
 		Config.save()


### PR DESCRIPTION
- The Rotation of the camera is no longer dependent on the angles of the neck (viewing is much more stable during scenes in Facecam mode, and saves your eyes well)
- The position of POV, direction and FOV (in Facecam mode) are now saved correctly after changing the H scenes.
- The direction, distance to the POV and FOV (in normal mode during H scenes) are now saved correctly and after leaving from Facecam mode successfully restored.
- Added "Starting FOV" parameter in mod config (Field of view on Activating Facecam).