### PR TITLE
Subtitles rework and HUD drawing on naked body fixes.

### DIFF
--- a/AAUnlimited/Files/Config.h
+++ b/AAUnlimited/Files/Config.h
@@ -48,7 +48,6 @@ public:;
 	bool bListFilenames;
 	bool bUnlimitedOnTop;
 	bool bExtractOnListing;
-	bool bDisplaySubs;
 
 	static inline void bindLua() {
 		LUA_SCOPE;
@@ -73,7 +72,6 @@ public:;
 			LUA_BIND(bListFilenames)
 			LUA_BIND(bUnlimitedOnTop)
 			LUA_BIND(bExtractOnListing)
-			LUA_BIND(bDisplaySubs)
 
 #undef LUA_CLASS
 		g_Lua[LUA_BINDING_TABLE]["Config"] = &g_Config;

--- a/AAUnlimited/Functions/AAPlay/Subs.h
+++ b/AAUnlimited/Functions/AAPlay/Subs.h
@@ -1,30 +1,22 @@
 #pragma once
 
-#include <d3d9.h>
-#include <string>
 #include <list>
 #include <regex>
 
 namespace Subtitles {
-	extern std::wstring text;
-	extern std::list<std::tuple< std::wstring, int >> lines;
-	extern const int fontLayersCount;
-	extern int outlineLayersCount;
-	extern RECT rect[];
-	extern D3DCOLOR colors[];
+	extern bool enabled;
 	extern int fontSize;
-	extern int lineHeight;
 	extern const char *fontFamily;
+	extern IUnknown *Font;
 	extern int gameWindowWidth;
-	extern DWORD subsCentered;
-	extern bool separateColorMale;
+	extern int gameWindowHeight;
 
 	void AddSubtitles(const char *subtitles, const char *file_name);
 	void InitSubtitlesParams(const char *font_family, int font_size, int line_height, int show_duration, int max_lines,
 		const char *text_color_female, int diff_color_for_male, const char *text_color_male, 
 		int outline_quality, int outline_spread, const char *outline_color, int outline_col_A,
 		int text_align, int area_pos_X, int area_pos_Y);
-	void CorrectSubsAreaSize();
+	void SetSubsAreaSize(int window_width, int window_height, int margin_Y);
 	void SetSubtitlesColor(int r, int g, int b);
-	void PopSubtitles();
+	void Render();
 }

--- a/AAUnlimited/Functions/RenderWrap.cpp
+++ b/AAUnlimited/Functions/RenderWrap.cpp
@@ -149,14 +149,10 @@ public:;
 	volatile size_t record;
 	bool exiting;
 	char buf[QSIZE];
-	IUnknown *font;
-	void *(WINAPI *DrawText)(IUnknown *, void*, LPCTSTR, int, LPRECT, DWORD, D3DCOLOR);
 	double real_time;
 
 	void DrawFPS() {
-		RECT rekt = { 0,0,256,64 };
 		wchar_t buf[64];
-
 		// every FRAME_MASK
 		if ((frameno & FRAME_MASK) == 0) {
 			DWORD now = GetTickCount();
@@ -166,84 +162,9 @@ public:;
 
 		_swprintf(buf, L"%02.2lf", 1000.0 * (FRAME_MASK + 1) / (real_time + 1));
 		//, real_time / (FRAME_MASK+1)
-		DrawText(font, 0, buf, -1, &rekt, DT_LEFT, 0xFFFFFFFF);
+		DrawD3D::DrawText(DrawD3D::fontFPS, 0, buf, -1, &DrawD3D::rectFPS, DT_LEFT, 0xFFFFFFFF);
 	}
 
-	void DrawSubs() {
-		Subtitles::PopSubtitles();
-		if (!Subtitles::lines.empty()) {
-
-			if (Subtitles::outlineLayersCount != 0 || Subtitles::separateColorMale)
-			{
-				int line_num = 0;
-				for each (const auto line in Subtitles::lines) // for each subs line
-				{
-					int top_offset = Subtitles::lineHeight * line_num;
-					RECT *tempRect;
-					for (int i = 0; i < Subtitles::outlineLayersCount; i++) // outline layers
-					{
-						tempRect = &Subtitles::rect[i];
-						tempRect->top = tempRect->top + top_offset;
-						tempRect->bottom = tempRect->bottom + top_offset;
-						DrawText(font, 0, std::get<0>(line).c_str(), -1, tempRect, DT_NOCLIP | Subtitles::subsCentered, Subtitles::colors[0]);
-						tempRect->top = tempRect->top - top_offset;
-						tempRect->bottom = tempRect->bottom - top_offset;
-					}
-					// Colorized text
-					tempRect = &Subtitles::rect[Subtitles::fontLayersCount - 1];
-					tempRect->top = tempRect->top + top_offset;
-					tempRect->bottom = tempRect->bottom + top_offset;
-					DrawText(font, 0, std::get<0>(line).c_str(), -1, &Subtitles::rect[Subtitles::fontLayersCount - 1], DT_NOCLIP | Subtitles::subsCentered, Subtitles::colors[std::get<1>(line)]);
-					tempRect->top = tempRect->top - top_offset;
-					tempRect->bottom = tempRect->bottom - top_offset;
-
-					line_num++;
-				}
-			}
-			else { // Only Colorized text
-				Subtitles::text.clear();
-				for each (const auto line in Subtitles::lines)
-					Subtitles::text += std::get<0>(line);
-				DrawText(font, 0, Subtitles::text.c_str(), -1, &Subtitles::rect[Subtitles::fontLayersCount - 1], DT_NOCLIP | Subtitles::subsCentered, Subtitles::colors[1]);
-			}
-		}
-	}
-
-	void MakeFont() {
-		// fuck you microsoft for the d3dx9 SDK stupidity, no way im installing that shit
-		font = 0;
-
-		const char *text = Subtitles::fontFamily;
-		int fontSize = Subtitles::fontSize;
-
-		if (text && fontSize) {
-			std::wstring fontName = General::utf8.from_bytes(text);
-
-			HMODULE hm = GetModuleHandleA("d3dx9_42");
-			void *(WINAPI *D3DXCreateFont)(
-				IDirect3DDevice9 *pDevice,
-				INT               Height,
-				UINT              Width,
-				UINT              Weight,
-				UINT              MipLevels,
-				BOOL              Italic,
-				DWORD             CharSet,
-				DWORD             OutputPrecision,
-				DWORD             Quality,
-				DWORD             PitchAndFamily,
-				LPCTSTR           pFacename,
-				IUnknown        **ppFont
-				);
-			D3DXCreateFont = decltype(D3DXCreateFont)(GetProcAddress(hm, "D3DXCreateFontW"));
-
-			D3DXCreateFont(orig, fontSize, 0, FW_ULTRABOLD, 1, false, DEFAULT_CHARSET,
-				OUT_DEFAULT_PRECIS, DEFAULT_QUALITY, DEFAULT_PITCH | FF_DONTCARE, fontName.c_str(), &font);
-
-			if (!font) return;
-
-			DrawText = decltype(DrawText)(((void***)font)[0][15]);
-		}
-	}
 
 	AAUIDirect3DDevice9(IDirect3DDevice9* old) {
 		play = record = 0;
@@ -251,7 +172,6 @@ public:;
 		ref = 1;
 		exiting = false;
 
-		MakeFont();
 		DrawD3D::InitDraw(orig);
 
 		if (!g_Config.bMTRenderer)
@@ -417,8 +337,8 @@ public:;
 		ULONG count = orig->Release();
 		if (!count) {
 //			LOGSPAM << "Releasing! ref=" << ref << "\n";
-			if (font)
-				font->Release();
+			if (DrawD3D::fontFPS)
+				DrawD3D::fontFPS->Release();
 			delete this;
 		}
 		return count;
@@ -629,20 +549,17 @@ public:;
 		if (!DrawD3D::canRender) {	// If drawing is temporarily not allowed
 			if (DrawD3D::waitRenderDelay)
 				DrawD3D::canRenderDelay();
+			//DrawD3D::DrawText(DrawD3D::fontFPS, 0, L"OFF", -1, &DrawD3D::rectFPS, DT_LEFT, D3DCOLOR_ARGB(200, 244, 244, 244));
 		}
 		else if (DrawD3D::fontCreated) {
-			DrawD3D::Render(); // HUD and others
-		}
-
-		if (font && g_Config.bDrawFPS || g_Config.bDisplaySubs) {
-			D3DVIEWPORT9 vp;
-			GetViewport(&vp);
-			if (vp.Width > 1024) {
-				if (g_Config.bDrawFPS)
+			if (g_Config.bDrawFPS) {
+				D3DVIEWPORT9 vp;
+				GetViewport(&vp);
+				if (vp.Width > 1024) 
 					DrawFPS();
-				if (g_Config.bDisplaySubs)
-					DrawSubs();
 			}
+			Subtitles::Render();
+			DrawD3D::Render(); // HUD and others
 		}
 		frameno++;
 
@@ -1117,13 +1034,13 @@ public:;
 		auto pret = *ppReturnedDeviceInterface;
 		d3dev = new AAUIDirect3DDevice9(pret);
 		if (hres == D3D_OK) {
-			Subtitles::gameWindowWidth = pPresentationParameters->BackBufferWidth; // Game window Width for Subtitles
-			Subtitles::CorrectSubsAreaSize();
 			int trueGameWindowWidth = pPresentationParameters->BackBufferWidth; // True game Width, Height for current resolution
 			int trueGameWindowHeight = trueGameWindowWidth / 16.00 * 9;
 			int trueGameMarginY = round((pPresentationParameters->BackBufferHeight - trueGameWindowHeight) / 2.0);
 			// Create D3D fonts
 			DrawD3D::MakeFonts(trueGameWindowWidth / 1920.0000000000, trueGameMarginY, hFocusWindow);
+			// Game window Width and Height for Subtitles
+			Subtitles::SetSubsAreaSize(trueGameWindowWidth, trueGameWindowHeight, trueGameMarginY);
 			*ppReturnedDeviceInterface = d3dev;
 			if (!created && General::IsAAPlay && g_Config.getb("bFullscreen")) {
 				DEVMODE dmScreenSettings = { 0 };

--- a/AAUnlimited/General/DrawD3D.cpp
+++ b/AAUnlimited/General/DrawD3D.cpp
@@ -466,6 +466,17 @@ namespace DrawD3D {
 			key_next = 0;
 
 
+		// FPS font
+		CreateFontD3d(24, 0, FW_ULTRABOLD, 1, false, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS,
+			DEFAULT_QUALITY, DEFAULT_PITCH | FF_DONTCARE, General::utf8.from_bytes("Arial").c_str(),
+			&fontFPS, false, "FPS Font creation failed");
+
+		// Subs Font
+		CreateFontD3d(Subtitles::fontSize, 0, FW_ULTRABOLD, 1, false, DEFAULT_CHARSET,
+			OUT_DEFAULT_PRECIS, DEFAULT_QUALITY, DEFAULT_PITCH | FF_DONTCARE,
+			General::utf8.from_bytes(Subtitles::fontFamily).c_str(),
+			&Subtitles::Font, false, "Subs Font creation failed");
+
 		// Other fonts
 		// ...
 

--- a/AAUnlimited/MemMods/AAPlay/Events/HInjections.cpp
+++ b/AAUnlimited/MemMods/AAPlay/Events/HInjections.cpp
@@ -9,6 +9,13 @@ ExtClass::CharacterStruct* loc_passiveChar = NULL;
 ExtClass::XXFile* loc_passiveFaceXX = NULL;
 ExtClass::XXFile* loc_activeFaceXX = NULL;
 DWORD loc_currPos = -1;
+bool cumshotStarted = false;
+byte* cumshotStart = 0;
+const DWORD cumshotStartOffset[]{ 0x3761CC, 0x28, 0x38, 0x70, 0xAC, 0x2C };
+byte* cumshotSprays = 0;
+const DWORD cumshotEndOffset[]{ 0x3761CC, 0x28, 0x38, 0x70, 0xAC, 0x34 };
+byte loc_cumshotSprays = 0;
+bool renderDelayStarted = false;
 
 bool (__stdcall *loc_OriginalTickFunction)(ExtClass::HInfo* info);
 
@@ -66,6 +73,34 @@ bool __stdcall TickRedirect(ExtClass::HInfo* hInfo) {
 			loc_passiveChar = passive;
 			loc_activeFaceXX = active->m_xxFace;
 			loc_passiveFaceXX = passive->m_xxFace;
+		}
+		// Detecting cumshot pose stage
+		cumshotStart = (byte*)ExtVars::ApplyRule(cumshotStartOffset);
+		if (!cumshotStarted && *cumshotStart == 1) {
+			LUA_EVENT_NORET("start_h_cumshot", hInfo);
+			cumshotStarted = true;
+			DrawD3D::canRender = false; // Fix against drawing on naked skin in cumshot stage
+			renderDelayStarted = false;
+		}
+		if (cumshotStarted) {
+			cumshotSprays = (byte*)ExtVars::ApplyRule(cumshotEndOffset); // Current count of released sprays
+			if (*cumshotSprays == 0)
+				loc_cumshotSprays = 0;
+			else if (*cumshotSprays != loc_cumshotSprays) {
+				loc_cumshotSprays = *cumshotSprays;
+				LUA_EVENT_NORET("cumshot_every_spray", loc_cumshotSprays);
+			}
+
+			if (*cumshotStart == 0) { // If cumshot end possible and sprays end
+				if (!renderDelayStarted) {
+					DrawD3D::canRenderDelay(30); // After little delay we can again draw a HUD
+					renderDelayStarted = true;
+				}
+				if (*cumshotSprays == 0) {
+					LUA_EVENT_NORET("end_h_cumshot", hInfo);
+					cumshotStarted = false;
+				}
+			}
 		}
 	}
 

--- a/AAUnlimited/MemMods/AAPlay/Events/Loads.cpp
+++ b/AAUnlimited/MemMods/AAPlay/Events/Loads.cpp
@@ -75,6 +75,7 @@ DWORD __declspec(noinline) __stdcall CallOrigLoad(DWORD who, void *_this, DWORD 
 	CharacterStruct *loadCharacter = (CharacterStruct*)_this;
 	Poser::LoadCharacter(loadCharacter);
 
+	DrawD3D::canRenderDelay(200); // Waiting 200 frames to prevent drawing HUD elements on naked skin
 	LUA_EVENT_NORET("char_spawn", loadCharacter, cloth, a3, a4, partial);
 	// Extra Hairs low poly infection fix
 	// Maker loads hair twice. Once after character is loaded. Fix can be safely ignored in Maker

--- a/AAUnlimited/Texts/mod/launcher/dlg.lua
+++ b/AAUnlimited/Texts/mod/launcher/dlg.lua
@@ -413,7 +413,6 @@ local function buildtabs() return
 				aaut("bUsePPeX", iup.toggle {title = "Use .ppx resource loader", tip="Connects to ppex resource daemon" }),
 				aaut("bUseMKIII", iup.toggle {title = "MKIII (chinpo .bmp->.tga texture)", tip="Enable/Disable modification for MKIII uncensor" }),
 				aaut("bListFilenames", iup.toggle {title = "List card file names", tip="List cards by filename in game instead of character name" }),
-				aaut("bDisplaySubs", iup.toggle {title = "Show subtitles", tip = "Shows game subtitles (needs subtitles script"}),
 			}
 		},
 	}, iup.fill{}, launch() },

--- a/AAUnlimited/Texts/mod/subtitles.lua
+++ b/AAUnlimited/Texts/mod/subtitles.lua
@@ -1,4 +1,4 @@
---@INFO Subtitles loader
+--@INFO Shows game subtitles
 
 local _M = {}
 local opts = {
@@ -18,8 +18,8 @@ local opts = {
 	{ "outlineColorA", 255, "Outline Alpha: %i[0,255]"},
 	
 	{ "textAlign", 0, "Text Alignment: %l|Left|Center|{(if `Center`, param `Position X` not working)}"},
-	{ "areaPosX", 15, "Subs Position X, px: %i[0,3000]{not works, if param `Alignment` set to `Center`}"},
-	{ "areaPosY", 45, "Subs Position Y, px: %i[0,3000]"},
+	{ "areaPosX", 1.0, "Subs Position X, percents: %r[0,100,0.1]{Percent of Game window Width (not works, if param `Alignment` set to `Center`)}"},
+	{ "areaPosY", 5.0, "Subs Position Y, percents: %r[0,100,0.1]{Percent of Game window Height}"},
 }
 
 local subtitles = {}
@@ -49,7 +49,7 @@ function on.launch()
 	InitSubtitlesParams(opts.fontFam, opts.fontSize, opts.lineHeight, opts.duration, opts.maxLines,
 		opts.textColFemale, opts.diffColForM, opts.textColMale, 
 		opts.outlineQuality, opts.outlineSpread, opts.outlineColor, opts.outlineColorA,
-		opts.textAlign, opts.areaPosX, opts.areaPosY)
+		opts.textAlign, math.ceil(opts.areaPosX * 100), math.ceil(opts.areaPosY * 100))
 end
 
 function _M:load()


### PR DESCRIPTION
- Now Subs and FPS drawing by using new DrawD3D.
- Fix: Position of Subs area now in percents of Game window Width and Height.
	(!) For users: please, correct Subs position in the Subs settings.
- Fix: Subs now have correct position on various Game window resolutions.
- Fix: Removed useless 'Show subtitles' checkbox from launcher settings.
- Fix: When communication start, all HUD elements temporary hides and not printed on naked skin of the girl (if she is naked).
- Fix: In cumshot stage now all HUD elements temporary hides and not printed with every spray on naked skin of the girl.