### PR TITLE
Triggers: Additional Get/Set functions for characters

### DIFF
--- a/AAUnlimited/Functions/Shared/Triggers/Actions.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Actions.cpp
@@ -701,6 +701,84 @@ namespace Shared {
 			AAPlay::g_characters[seat].m_char->m_charData->m_character.fightingStyle = fightingStyle % 3;
 		}
 
+		//int seat, int figure
+		void Thread::SetCardFigure(std::vector<Value>& params)
+		{
+			int seat = params[0].iVal;
+			if (ActionSeatInvalid(seat)) return;
+			int figure = params[1].iVal;
+			if (!AAPlay::g_characters[seat].IsValid()) {
+				LOGPRIO(Logger::Priority::WARN) << "[Trigger] Invalid card target; seat number " << seat << "\r\n";
+				return;
+			}
+			AAPlay::g_characters[seat].m_char->m_charData->m_figure.figure = figure % 3;
+		}
+
+		//int seat, int breastSize
+		void Thread::SetCardBreastSize(std::vector<Value>& params)
+		{
+			int seat = params[0].iVal;
+			if (ActionSeatInvalid(seat)) return;
+			int breastSize = params[1].iVal;
+			if (!AAPlay::g_characters[seat].IsValid()) {
+				LOGPRIO(Logger::Priority::WARN) << "[Trigger] Invalid card target; seat number " << seat << "\r\n";
+				return;
+			}
+			AAPlay::g_characters[seat].m_char->m_charData->m_chest.size= (breastSize % 4) * 25;
+		}
+
+		//int seat, int breastSize
+		void Thread::SetCardRawBreastSize(std::vector<Value>& params)
+		{
+			int seat = params[0].iVal;
+			if (ActionSeatInvalid(seat)) return;
+			int breastSize = params[1].iVal;
+			if (!AAPlay::g_characters[seat].IsValid()) {
+				LOGPRIO(Logger::Priority::WARN) << "[Trigger] Invalid card target; seat number " << seat << "\r\n";
+				return;
+			}
+			AAPlay::g_characters[seat].m_char->m_charData->m_chest.size = breastSize % 256;
+		}
+
+		//int seat, int shape
+		void Thread::SetCardBreastShape(std::vector<Value>& params)
+		{
+			int seat = params[0].iVal;
+			if (ActionSeatInvalid(seat)) return;
+			int shape = params[1].iVal;
+			if (!AAPlay::g_characters[seat].IsValid()) {
+				LOGPRIO(Logger::Priority::WARN) << "[Trigger] Invalid card target; seat number " << seat << "\r\n";
+				return;
+			}
+			AAPlay::g_characters[seat].m_char->m_charData->m_chest.shape = shape % 4;
+		}
+
+		//int seat, int softness
+		void Thread::SetCardBreastSoftness(std::vector<Value>& params)
+		{
+			int seat = params[0].iVal;
+			if (ActionSeatInvalid(seat)) return;
+			int softness = params[1].iVal;
+			if (!AAPlay::g_characters[seat].IsValid()) {
+				LOGPRIO(Logger::Priority::WARN) << "[Trigger] Invalid card target; seat number " << seat << "\r\n";
+				return;
+			}
+			AAPlay::g_characters[seat].m_char->m_charData->m_chest.softness = softness % 3;
+		}
+
+		//int seat, int height
+		void Thread::SetHeight(std::vector<Value>& params)
+		{
+			int seat = params[0].iVal;
+			if (ActionSeatInvalid(seat)) return;
+			int height = params[1].iVal;
+			if (!AAPlay::g_characters[seat].IsValid()) {
+				LOGPRIO(Logger::Priority::WARN) << "[Trigger] Invalid card target; seat number " << seat << "\r\n";
+				return;
+			}
+			AAPlay::g_characters[seat].m_char->m_charData->m_figure.height = height % 3;
+		}
+
 		//int seat, int value
 		void Thread::SetCharacterLocked(std::vector<Value>& params)
 		{
@@ -2121,11 +2199,11 @@ namespace Shared {
 				&Thread::SetNpcResponseStrongPercent
 			},
 			{
-				96, ACTIONCAT_EVENT, TEXT("Set Npc Absolute Response Percent"), TEXT("NPCAbsoluteResponsePercent = %p"),
-				TEXT("When executed with a Npc Answers Event, this can be used to modify the success percentage showed. Note that changing this value "
-				"does not influence the Nps Answer, as it has allready been made. This Action only modifies the Percentage displayed in the UI. Adhers to the following priority and override each other: Normal < Strong < Absolute."),
-				{ TYPE_INT },
-				&Thread::SetNpcResponseAbsolutePercent
+96, ACTIONCAT_EVENT, TEXT("Set Npc Absolute Response Percent"), TEXT("NPCAbsoluteResponsePercent = %p"),
+TEXT("When executed with a Npc Answers Event, this can be used to modify the success percentage showed. Note that changing this value "
+	"does not influence the Nps Answer, as it has allready been made. This Action only modifies the Percentage displayed in the UI. Adhers to the following priority and override each other: Normal < Strong < Absolute."),
+{ TYPE_INT },
+&Thread::SetNpcResponseAbsolutePercent
 			},
 			{
 				97, ACTIONCAT_EVENT, TEXT("Set Npc Absolute Response Success"), TEXT("NPCAbsoluteResponseSuccess = %p"),
@@ -2198,6 +2276,42 @@ namespace Shared {
 				TEXT("Display the notification on the screen."),
 				{ TYPE_STRING, TYPE_BOOL },
 				&Thread::Notification
+			},
+			{
+				109, ACTIONCAT_MODIFY_CHARACTER, TEXT("Set Figure"), TEXT("%p ::Figure = %p"),
+				TEXT("Set the figure of the character. 0=thin, 1=normal, 2=chubby."),
+				{ TYPE_INT, TYPE_INT },
+				&Thread::SetCardFigure
+			},
+			{
+				110, ACTIONCAT_MODIFY_CHARACTER, TEXT("Set Breast Size"), TEXT("%p ::BreastSize = %p"),
+				TEXT("Set the breast size of a character. 0 = flat, 1 = small, 2 = medium, 3 = large, 4 = XL."),
+				{ TYPE_INT, TYPE_INT },
+				&Thread::SetCardBreastSize
+			},
+			{
+				111, ACTIONCAT_MODIFY_CHARACTER, TEXT("Set Raw Breast Size"), TEXT("%p ::RawBreastSize = %p"),
+				TEXT("Set the breast size of a character (raw value). 0 = flat, 100 = vanilla max, 255 = absolute max."),
+				{ TYPE_INT, TYPE_INT },
+				&Thread::SetCardRawBreastSize
+			}, 
+			{
+				112, ACTIONCAT_MODIFY_CHARACTER, TEXT("Set Breast Shape"), TEXT("%p ::BreastShape = %p"),
+				TEXT("Set breast shape of the character. Ranges from 0 (roundest) to 3 (pointiest)."),
+				{ TYPE_INT, TYPE_INT },
+				&Thread::SetCardBreastShape
+			}, 
+			{
+				113, ACTIONCAT_MODIFY_CHARACTER, TEXT("Set Breast Softness"), TEXT("%p ::BreastSoftness = %p"),
+				TEXT("Set breast softness of the character. 0 = soft, 1 = medium, 2 = hard."),
+				{ TYPE_INT, TYPE_INT },
+				&Thread::SetCardBreastSoftness
+			},
+			{
+				114, ACTIONCAT_MODIFY_CHARACTER, TEXT("Set Height"), TEXT("%p ::Height = %p"),
+				TEXT("Set the height of the character. 0=short, 1=normal, 2=tall."),
+				{ TYPE_INT, TYPE_INT },
+				&Thread::SetHeight
 			}
 		};
 

--- a/AAUnlimited/Functions/Shared/Triggers/Expressions.cpp
+++ b/AAUnlimited/Functions/Shared/Triggers/Expressions.cpp
@@ -573,7 +573,7 @@ namespace Shared {
 				int decValue = 92 * towards + feeling;
 				return Value(AAPlay::g_characters[seat].m_char->m_moreData2->ai01_03[0][decValue]);
 
-			}
+		}
 
 		Value Thread::GetCardFigure(std::vector<Value>& params) {
 			int seat = params[0].iVal;
@@ -602,12 +602,55 @@ namespace Shared {
 			{
 				int size = (int)(inst->m_char->m_charData->m_chest.size);
 				if (size <= 33) return Value(0);
-				if ((size > 33) && (size <=66)) return Value(1);
+				if ((size > 33) && (size <= 66)) return Value(1);
 				if (size > 66) return Value(2);
 			}
 		}
+		
+		Value Thread::GetCardRawBreastSize(std::vector<Value>& params) {
+			int seat = params[0].iVal;
+			if (ExpressionSeatInvalid(seat)) return Value(-1);
+			CharInstData* inst = &AAPlay::g_characters[seat];
+			if (!inst->IsValid())
+			{
+				return -1;
+			}
+			else
+			{
+				int size = (int)(inst->m_char->m_charData->m_chest.size);
+				return Value(size);
+			}
+		}
 
+		Value Thread::GetCardBreastShape(std::vector<Value>& params) {
+			int seat = params[0].iVal;
+			if (ExpressionSeatInvalid(seat)) return Value(-1);
+			CharInstData* inst = &AAPlay::g_characters[seat];
+			if (!inst->IsValid())
+			{
+				return -1;
+			}
+			else
+			{
+				int shape = (int)(inst->m_char->m_charData->m_chest.shape);
+				return Value(shape);
+			}
+		}
 
+		Value Thread::GetCardBreastSoftness(std::vector<Value>& params) {
+			int seat = params[0].iVal;
+			if (ExpressionSeatInvalid(seat)) return Value(-1);
+			CharInstData* inst = &AAPlay::g_characters[seat];
+			if (!inst->IsValid())
+			{
+				return -1;
+			}
+			else
+			{
+				int soft = (int)(inst->m_char->m_charData->m_chest.softness);
+				return Value(soft);
+			}
+		}
 
 		//int(int)
 		Value Thread::GetCardPersonality(std::vector<Value>& params) {
@@ -3064,6 +3107,24 @@ namespace Shared {
 					TEXT("Returns the number of seconds that have passed in the current period."),
 					{}, (TYPE_INT),
 					&Thread::GetPeriodTimer
+				},
+				{
+					121, EXPRCAT_CHARPROP,
+					TEXT("Get Raw Breast Size"), TEXT("%p ::RawBreastSize"), TEXT("Get breast size of the character. Vanilla max = 100, absolute max = 255"),
+					{ TYPE_INT }, (TYPE_INT),
+					&Thread::GetCardRawBreastSize
+				},
+				{
+					122, EXPRCAT_CHARPROP,
+					TEXT("Get Breast Shape"), TEXT("%p ::BreastShape"), TEXT("Get breast shape of the character. Ranges from 0 (roundest) to 3 (pointiest)."),
+					{ TYPE_INT }, (TYPE_INT),
+					&Thread::GetCardBreastShape
+				}, 
+				{
+					123, EXPRCAT_CHARPROP,
+					TEXT("Get Breast Softness"), TEXT("%p ::BreastSoftness"), TEXT("Get breast softness of the character. 0 = soft, 1 = medium, 2 = hard."),
+					{ TYPE_INT }, (TYPE_INT),
+					&Thread::GetCardBreastSoftness
 				},
 			},
 

--- a/AAUnlimited/Functions/Shared/Triggers/Thread.h
+++ b/AAUnlimited/Functions/Shared/Triggers/Thread.h
@@ -89,6 +89,12 @@ namespace Shared {
 			void SetCardIntelligenceRank(std::vector<Value>& params);
 			void SetCardStrength(std::vector<Value>& params);
 			void SetCardFightingStyle(std::vector<Value>& params);
+			void SetCardFigure(std::vector<Value>& params);
+			void SetCardBreastSize(std::vector<Value>& params);
+			void SetCardRawBreastSize(std::vector<Value>& params);
+			void SetCardBreastShape(std::vector<Value>& params);
+			void SetCardBreastSoftness(std::vector<Value>& params);
+			void SetHeight(std::vector<Value>& params);
 			void SetCharacterLocked(std::vector<Value>& params);
 			void SetActionAboutRoom(std::vector<Value>& params);
 			void SetMasturbating(std::vector<Value>& params);
@@ -204,8 +210,10 @@ namespace Shared {
 			Value GetCardPreference(std::vector<Value>& params);
 			Value GetCardOpinion(std::vector<Value>& params);
 			Value GetCardFigure(std::vector<Value>& params);
-
 			Value GetCardBreastSize(std::vector<Value>& params);
+			Value GetCardRawBreastSize(std::vector<Value>& params);
+			Value GetCardBreastShape(std::vector<Value>& params);
+			Value GetCardBreastSoftness(std::vector<Value>& params);
 
 			//bool(int, int)
 			Value GetCardPersonality(std::vector<Value>& params); //int(int)


### PR DESCRIPTION
GetGardRawBreastSize: Returns the breast size as displayed by Maker (0-255) rather than simplifying to general size
GetBreastShape: Returns character's breast shape (0-4, corresponding to the buttons from left to right in Maker)
GetBreastSoftness: Returns character's breast softness (0/1/2 = soft/med/hard respectively)

SetCardFigure: Sets the figure of a specified character (thin/normal/chubby)
SetHeight: Sets the height of a specified character (low/normal/high)
SetCardBreastSize: Sets character's breast size roughly in line with the value of the existing GetBreastSize function. Ranges from 0 (flat) to 4 (vanilla max size)
Plus Set functions matching the new Get functions implemented above